### PR TITLE
docs: de-google the project with references to MNF

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,9 +273,10 @@
     <div class="container">
       <div class="row">
         <div class="col-xs-12 col-md-11">
-          <a href="https://www.google.com/policies/terms/">Terms</a> | <a href="https://www.google.com/policies/privacy/">Privacy</a> Updated Jan 27, 2017
+          <a href="https://lfprojects.org/policies/terms-of-use/">Terms</a> | <a href="https://lfprojects.org/policies/privacy-policy/">Privacy</a> Updated Sept 6, 2019
         </div>
       </div>
     </div>
   </div>
 </body>
+


### PR DESCRIPTION
Removes references to Google.

 Others
   - https://github.com/fastlane/fastlane.tools/pull/97
   - https://github.com/fastlane/fastlane/pull/29747
   - https://github.com/fastlane/code-of-conduct/pull/2